### PR TITLE
Fix broken GitHub pipeline

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -11,10 +11,10 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Assemble with Gradle
-      uses: burrunan/gradle-cache-action@v1
+      uses: burrunan/gradle-cache-action@v2
       with:
         arguments: assemble
         gradle-version: wrapper

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -20,7 +20,7 @@ jobs:
         gradle-version: wrapper
 
     - name: Upload to Build Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: azure-devops-plugin-1.0-SNAPSHOT
         path: build/libs/azure-devops-plugin-1.0-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ Most of the standard Task Management features are supported:
 These features aren't supported:
 - [ ] Comments
 - [ ] Time tracking
+
+Making a change to the reader, to trigger GitHub actions

--- a/README.md
+++ b/README.md
@@ -34,4 +34,6 @@ These features aren't supported:
 - [ ] Comments
 - [ ] Time tracking
 
-Making a change to the reader, to trigger GitHub actions
+## Changelog
+### 2025-04-08 
+- Updated the GitHub pipeline to use the latest version of the upstream GitHub action, fixes failure to run due to dependency on retired version


### PR DESCRIPTION
Hi there,

Thanks for contributing this plugin! I noticed that the artifact in the last GitHub action pipeline run has no expired, so I created a fork and ran the pipeline. I found that one of the upstream GitHub Action libraries (if that is the right term) is now retired, which causes the pipeline to fail, so I've updated them to the latest version. I can confirm I was able to build an artifact and run the plugin in PyCharm.

@mattkleiny Please review and merge in this pull request!

All the best,
tur-ium